### PR TITLE
Update Atlas CLI version and silence warning updates

### DIFF
--- a/template_notebook.ipynb
+++ b/template_notebook.ipynb
@@ -22,8 +22,13 @@
    "source": [
     "# Install the Atlas CLI\n",
     "\n",
-    "!wget https://fastdl.mongodb.org/mongocli/mongodb-atlas-cli_1.43.1_linux_x86_64.deb\n",
-    "!sudo dpkg -i mongodb-atlas-cli_1.43.1_linux_x86_64.deb"
+    "!wget https://fastdl.mongodb.org/mongocli/mongodb-atlas-cli_1.43.2_linux_x86_64.deb\n",
+    "!sudo dpkg -i mongodb-atlas-cli_1.43.2_linux_x86_64.deb\n",
+    "\n",
+    "!atlas --version\n",
+    "\n",
+    "# silence warnings about updates\n",
+    "!atlas config set skip_update_check true "
    ]
   },
   {

--- a/template_notebook.ipynb
+++ b/template_notebook.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "# Install the Atlas CLI\n",
     "\n",
-    "!wget https://fastdl.mongodb.org/mongocli/mongodb-atlas-cli_1.43.2_linux_x86_64.deb\n",
+    "!wget https://fastdl.mongodb.org/mongocli/mongodb-atlas-cli_1.46.3_linux_x86_64.deb\n",
     "!sudo dpkg -i mongodb-atlas-cli_1.43.2_linux_x86_64.deb\n",
     "\n",
     "!atlas --version\n",


### PR DESCRIPTION
This PR updates Atlas CLI to the latest 1.46.3 version and adds a command to silence the warning updates that polluted the output in each cell.